### PR TITLE
Change cert.get_fingerprint to str type

### DIFF
--- a/pupy/pupylib/PupyCredentials.py
+++ b/pupy/pupylib/PupyCredentials.py
@@ -290,7 +290,7 @@ class Credentials(object):
         cert.set_issuer(cert.get_subject())
         cert.set_pubkey(pk)
         cert.add_ext(X509.new_extension('basicConstraints', 'CA:TRUE'))
-        cert.add_ext(X509.new_extension('subjectKeyIdentifier', cert.get_fingerprint()))
+        cert.add_ext(X509.new_extension('subjectKeyIdentifier', str(cert.get_fingerprint())))
         cert.sign(pk, 'sha256')
 
         return pk.as_pem(cipher=None), cert.as_pem(), pk, cert
@@ -316,7 +316,7 @@ class Credentials(object):
         cert.set_issuer(ca_cert.get_subject())
         cert.set_pubkey(pk)
         cert.add_ext(X509.new_extension('basicConstraints', 'critical,CA:FALSE'))
-        cert.add_ext(X509.new_extension('subjectKeyIdentifier', cert.get_fingerprint()))
+        cert.add_ext(X509.new_extension('subjectKeyIdentifier', str(cert.get_fingerprint())))
         if client:
             cert.add_ext(X509.new_extension('keyUsage', 'critical,digitalSignature'))
             cert.add_ext(X509.new_extension('nsCertType', 'client'))


### PR DESCRIPTION
A recent commit in M2crypto changed the return type of X509.get_fingerprint() from 'str' to 'unicode' in Python2.
https://gitlab.com/m2crypto/m2crypto/commit/b977909fc93caa599e52943be25b7f6042a4c70b

However the 2nd parameter in X509.new_extension expect a 'str' type instead of 'unicode' type. This commit convert the return value of cert.get_fingerprint to a 'str' so it can continue to work.